### PR TITLE
linters and tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,22 @@
+# .coveragerc to control coverage.py
+[run]
+branch = False
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+ignore_errors = False
+
+[html]
+directory = coverage_html_report

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,5 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <settings>
+    <option name="PROJECT_PROFILE" value="Default" />
     <option name="USE_PROJECT_PROFILE" value="false" />
     <version value="1.0" />
   </settings>

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,15 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
+pycodestyle = "*"
+pydocstyle = "*"
+mccabe = "*"
+mypy = "*"
+autopep8 = "*"
+pyflakes = "*"
+flake8 = "*"
+pytest = "*"
+pytest-cov = "*"
 
 [requires]
 python_version = "3.8"

--- a/main/main.py
+++ b/main/main.py
@@ -1,8 +1,12 @@
-def main():
+def main() -> None:
     s = "eric writes silly variable names"
-    print(s)
+    test_string = "Hello"
+    print("{} - {}".format(s, test_string))
 
-    test_string = "Hello";
 
-if __name__=='__main__':
+def test_func_with_type(arg: str) -> bool:
+    return arg == "nothing"
+
+
+if __name__ == '__main__':
     main()

--- a/run_linters.py
+++ b/run_linters.py
@@ -1,0 +1,38 @@
+import subprocess
+import sys
+import typing
+
+
+def main() -> None:
+    is_success: bool = True
+    for linter_input in [
+            ['flake8', '--max-complexity', '8' '.'],
+            ['mypy', '--strict', '.'],
+            ['pydocstyle', '.'],
+    ]:
+        this_success = run_single_linter(linter_input)
+        is_success = is_success and this_success
+
+    if is_success:
+        print("all linters pass")
+        sys.exit(0)
+    else:
+        print("linter failure")
+        sys.exit(-1)
+
+
+def run_single_linter(args: typing.List[str]) -> bool:
+    """returns true if the linter passes, and false if it fails"""
+    p = subprocess.run(args, stdout=subprocess.PIPE,
+                       stderr=subprocess.PIPE, text=True)
+    if p.returncode != 0:
+        print("{} failure:".format(args[0]))
+        print(p.stdout)
+        return False
+    else:
+        print("{} success".format(args[0]))
+        return True
+
+
+if __name__ == "__main__":
+    main()

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,40 @@
+import subprocess
+import sys
+import typing
+
+
+def main() -> None:
+    is_success: bool = True
+    p = subprocess.run(['pytest'], stdout=subprocess.PIPE,
+                       stderr=subprocess.PIPE, text=True)
+    for test_input in [
+        ['pytest', '.'],
+        ['pytest', '--cov=main', '.'],
+    ]:
+        this_success = run_tests(test_input)
+        is_success = is_success and this_success
+
+    if is_success:
+        print("all tests pass")
+        sys.exit(0)
+    else:
+        print("test failure")
+        sys.exit(-1)
+
+
+def run_tests(args: typing.List[str]) -> bool:
+    """returns true if the linter passes, and false if it fails"""
+    p = subprocess.run(args, stdout=subprocess.PIPE,
+                       stderr=subprocess.PIPE, text=True)
+    print(p.stdout)
+    if p.returncode != 0:
+        print("{} failure:".format(args[0]))
+        print(p.stdout)
+        return False
+    else:
+        print("{} success".format(args[0]))
+        return True
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,8 @@
+import main.main
+
+
+def test_main() -> None:
+    assert main.main.test_func_with_type("nothing")
+    assert not main.main.test_func_with_type("something")
+    # shouldn't throw
+    main.main.main()


### PR DESCRIPTION
add run_linters.py, run_tests.py, a test for main.py, and some fixes in main.py based on linter output.

See https://en.wikipedia.org/wiki/Lint_(software)
The linters here allow us to treat some legal python code and patterns as errors so that we can keep the code cleaner than is strictly necessary:
* flake8 -- pyflakes: finds bad patterns that are almost certainly bugs, but won't cause parsing/syntax errors
* flake8 -- pycodestyle: verifies that our code style adheres to "pep8" -- https://www.python.org/dev/peps/pep-0008/
* flake8 -- mccabe: enforces that no file, class, or method is too complex using a heuristic
* pydocstyle: enforces that all classes and methods have proper doc strings
* mypy: enforces that we will use Python's optional static type annotations and that there are no errors.

tests:
* use pytest and run all applicable tests in the project.  This includes any files matching test\_\*.py or \*\_test.py and any contained methods matching test_*()
* provide code coverage for all these tests.  See .coveragerc for coverage testing configuration.
* the eventual goal is to automatically reject a pull request if it does not have 100% code coverage or if any test fails.

next TODOs:
* add docstrings so that the linters all pass
* integrate autopep8 on pycharm file save
* add a github action for linters and tests.