### PR TITLE
monkey patch json serializer

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,22 @@
 """Primary package."""
+import json
+import typing
+
+
+# monkey patch json's encoder to search for a to_json method
+# if found default() returns the result of to_json
+_original_default = json.JSONEncoder().default
+
+
+def _default(self: json.JSONEncoder, o: typing.Any) -> typing.Any:
+    try:
+        f = getattr(o.__class__, "json_default")
+    except AttributeError:
+        return _original_default(o)
+    else:
+        return f(o)
+
+
+# ignore typing.  mypy doesn't like assigning a function/method,
+# but this is the essence of monkey patching
+json.JSONEncoder.default = _default  # type: ignore

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,3 @@
 """Provide tests for the project."""
+# import src to force json monkey patch for all tests
+import src  # noqa: F401

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,54 @@
+import json
+import pytest
+import typing
+
+
+class A(object):
+    def json_default(self) -> typing.Any:
+        """Define serialization."""
+        return [1, 2, 3]
+
+
+class B(object):
+    def __init__(self, obj: typing.Any):
+        self.obj = obj
+
+    def json_default(self) -> typing.Any:
+        """Define serialization."""
+        return {"obj": self.obj}
+
+
+class C(object):
+    pass
+
+
+def test_json_monkey_patch() -> None:
+    """test that json serialization works.
+
+    Classes/objects with json_default() should use that method
+    to provide a serializable object.
+    Objects without should use normal serialization."""
+    assert json.dumps({"a": 1}) == '{"a": 1}'
+
+    obj = {
+        "a": A(),
+        "b with a": B(A()),
+        "b with b with dict": B(B({"asdf": 1}))}
+    s = json.dumps(obj)
+    assert s == ('{"a": [1, 2, 3], "b with a": {"obj": [1, 2, 3]},'
+                 ' "b with b with dict": {"obj": {"obj": {"asdf": 1}}}}')
+
+    with pytest.raises(
+            TypeError,
+            match="Object of type C is not JSON serializable"):
+        json.dumps(C())
+
+    with pytest.raises(
+            TypeError,
+            match="Object of type C is not JSON serializable"):
+        json.dumps({"a": C()})
+
+    with pytest.raises(
+            TypeError,
+            match="Object of type C is not JSON serializable"):
+        json.dumps(B(C()))


### PR DESCRIPTION
Any class may define a method json_default to define its serialization.  This method follows the convention of JSONEncoder::default.

Added tests for serialization and patching via package loading.

Changed inputdto DTO classes to define json serialization and have __str__ delegate to this serialization.

Added some small logging to inputdto.